### PR TITLE
Fix 'key1=value1&key2=&key3=value3' case

### DIFF
--- a/aws-api-gateway-bodyparser.vtl
+++ b/aws-api-gateway-bodyparser.vtl
@@ -24,7 +24,7 @@
   #foreach( $param in $params )
     #set( $key = $util.urlDecode($param[0]) )
 
-    #if( $param.size() > 1 )
+    #if( $param.size() > 1 && $param[1].length() > 0 )
       #set( $value = $util.urlDecode($param[1]) )
     #else
       #set( $value = "" )


### PR DESCRIPTION
When the Value in a key value pair is 0 length, `$util.urlDecode` seems to fail on decoding.

Fixed by only decoding if value is non-zero length.